### PR TITLE
Updated build to fix conflict. This should clear up build warnings.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,7 +159,9 @@ dependencies {
     compile group: 'com.squareup.okhttp', name: 'okhttp', version: '1.3.0'
     compile group: 'com.squareup.okhttp', name: 'okhttp-apache', version: '1.3.0'
     compile group: 'com.squareup.retrofit', name: 'retrofit', version: '1.5.0'
-    compile group: 'org.simpleframework', name: 'simple-xml', version: '2.6.3'
+    compile ([group: 'org.simpleframework', name: 'simple-xml', version: '2.6.3']){
+        exclude group: 'xpp3'
+    }
     compile group: 'com.readystatesoftware.sqliteasset', name: 'sqliteassethelper', version: '+'
     compile group: 'com.andraskindler.quickscroll', name: 'quickscroll', version: '0.9.8'
     compile('de.keyboardsurfer.android.widget:crouton:1.8.4') {


### PR DESCRIPTION
Please test this and make sure it clears up warnings and does not cause any other issues. Warnings were based around the inclusion of xpp3 as a dependency in the framework when a version is already included in Android. 
